### PR TITLE
Updated the build number api used

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,8 +21,8 @@ class EditMe:
 
     def _get_build_number(self):
         try:
-            response = self.session.get("https://raw.githubusercontent.com/Pixens/Discord-Build-Number/refs/heads/main/discord.json")
-            return int(response.json()['client_build_number'])
+            response = self.session.get("https://api.sockets.lol/discord/build")
+            return int(response.json()['build'])
         except:
             return 345368
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/87d55ed6-3c1c-4fb5-8b7c-fc499c751790)
^ Old one (client_build_number) is also not the latest one.

I updated to https://api.sockets.lol/discord/build which is more reliable.
